### PR TITLE
Fixed missing double empty line after foundValue in GetValueFromReadme.

### DIFF
--- a/pasta/pasta.cpp
+++ b/pasta/pasta.cpp
@@ -60,7 +60,7 @@ BOOL GetValueFromReadme(const char* readmeContents, const char* valueName, BYTE*
 	// TODO: probably a cleaner way to do this
 	if (!foundValueEnd)
 	{
-		foundValueEnd = foundValue + strlen(readmeContents);
+		foundValueEnd = strchr(foundValue, '\0');
 	}
 
 	foundValueLength = (size_t)(foundValueEnd - foundValue);


### PR DESCRIPTION
The original idea seems to be to find the end of the string, so I did it using strchr,
the code before this commit is overflowing the length, because it will add the entire
string length counting twice the position, it could be the initial string pointer plus
the entire string length "readmeContents + strlen(readmeContents)" or current pointer
position plus the length of the current position "foundValue + strlen(foundValue)",
but not both.

Without this commit, it may fail depending on the CryptStringToBinaryA behavior when it
encounters the string terminator before the length as it is not a valid base64 character.